### PR TITLE
add html statement snapshot for JS

### DIFF
--- a/javascript/test/__snapshots__/htmlStatement.js.snap
+++ b/javascript/test/__snapshots__/htmlStatement.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`example html statement 1`] = `
+"<h1>Statement for BigCo</h1>
+<table>
+ <tr><th>play</th><th>seats</th><th>cost</th></tr>
+ <tr><td>Hamlet</td><td>55</td><td>$650.00</td></tr>
+ <tr><td>As You Like It</td><td>35</td><td>$580.00</td></tr>
+ <tr><td>Othello</td><td>40</td><td>$500.00</td></tr>
+</table>
+<p>Amount owed is <em>$1,730.00</em></p>
+<p>You earned <em>47</em> credits</p>
+"
+`;


### PR DESCRIPTION
Added HTML statement snapshot for approval tests.
I didn't add the test for HTML because it could force developers to use a specific design. Test for HTML statement can be easily created from current statement tests.